### PR TITLE
RCLOUD-1185: Update PluginMetaDataProvider

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.1'
+version = '1.0.2'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/org/rundeck/app/data/providers/v1/pluginmeta/PluginMetaDataProvider.java
+++ b/src/main/java/org/rundeck/app/data/providers/v1/pluginmeta/PluginMetaDataProvider.java
@@ -27,5 +27,5 @@ public interface PluginMetaDataProvider extends DataProvider {
     void deleteByProjectAndKey(String project, String key);
     void deleteAllByProjectAndKeyLike(String project, String keyLike);
     Integer deleteAllByProject(String project);
-    void setJobPluginMeta(String project, String id, String type, Map key);
+    void setJobPluginMeta(String project, String key, Map metadata);
 }


### PR DESCRIPTION
Remove the unused `id` argument from `setJobPluginMeta` and rename the arguments for better understanding.