### PR TITLE
RUN-3717: modify data providers to get the execs id instead of uuid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,10 +27,12 @@ dependencies {
 }
 
 nexusPublishing {
+    packageGroup = 'org.rundeck'
     repositories {
-        sonatype {
-            username = findProperty('sonatypeUsername')
-            password = findProperty('sonatypePassword')
+        sonatype{
+            stagingProfileId = '67d196ce5bae'
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.6'
+version = '1.0.7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/build.gradle
+++ b/build.gradle
@@ -26,17 +26,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }
 
-nexusPublishing {
-    packageGroup = 'org.rundeck'
-    repositories {
-        sonatype{
-            stagingProfileId = '67d196ce5bae'
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-        }
-    }
-}
-
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -66,18 +55,19 @@ publishing {
             }
         }
     }
+}
+
+nexusPublishing {
     repositories {
-        maven {
-            def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
-            def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
-            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
-            credentials {
-                username findProperty('sonatypeUsername')
-                password findProperty('sonatypePassword')
-            }
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username findProperty('sonatypeUsername')
+            password findProperty('sonatypePassword')
         }
     }
 }
+
 
 if(findProperty("signing.keyId") != null && findProperty("signing.password") != null) {
     signing {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.7-SNAPSHOT'
+version = '1.0.7'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -24,6 +24,19 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"
     testImplementation platform('org.junit:junit-bom:5.9.1')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+nexusPublishing {
+    packageGroup = 'org.rundeck'
+    repositories {
+        sonatype{
+            stagingProfileId = '67d196ce5bae'
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(findProperty('sonatypeUsername'))
+            password.set(findProperty('sonatypePassword'))
+        }
+    }
 }
 
 publishing {
@@ -56,18 +69,6 @@ publishing {
         }
     }
 }
-
-nexusPublishing {
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-            username findProperty('sonatypeUsername')
-            password findProperty('sonatypePassword')
-        }
-    }
-}
-
 
 if(findProperty("signing.keyId") != null && findProperty("signing.password") != null) {
     signing {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.7-SNAPSHOT'
+version = '1.0.8-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.7'
+version = '1.0.7-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -66,8 +66,8 @@ publishing {
     }
     repositories {
         maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            def releasesRepoUrl = 'https://ossrh-staging-api.central.sonatype.com/service/local/'
+            def snapshotsRepoUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
             url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
             credentials {
                 username findProperty('sonatypeUsername')

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = 'org.rundeck'
 archivesBaseName = 'rundeck-data-models'
-version = '1.0.8-SNAPSHOT'
+version = '1.0.7-SNAPSHOT'
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11

--- a/src/main/java/org/rundeck/app/data/providers/v1/execution/ReferencedExecutionDataProvider.java
+++ b/src/main/java/org/rundeck/app/data/providers/v1/execution/ReferencedExecutionDataProvider.java
@@ -27,9 +27,15 @@ public interface ReferencedExecutionDataProvider extends DataProvider {
     RdReferencedExecution findByJobUuid(String jobUuid);
     List<JobDataSummary> parentJobSummaries(String jobUuid, int max);
     List<String> executionProjectList(String jobUuid, int max);
-    List<String> getExecutionUuidsByJobUuid(String jobUuid);
     int countByJobUuid(String jobUuid);
     int countByJobUuidAndStatus(String jobUuid, String status);
     void deleteByExecutionId(Long id);
     void deleteByJobUuid(String jobUuid);
+
+    /**
+     * Get executions id by job uuid
+     * @param jobUuid job uuid
+     * @return list of execution ids
+     */
+    List<Long> getExecutionIdsByJobUuid(String jobUuid);
 }

--- a/src/main/java/org/rundeck/app/data/providers/v1/report/ExecReportDataProvider.java
+++ b/src/main/java/org/rundeck/app/data/providers/v1/report/ExecReportDataProvider.java
@@ -32,10 +32,31 @@ public interface ExecReportDataProvider extends DataProvider {
     List<RdExecReport> findAllByProjectAndExecutionUuidInList(String projectName, List<String> execUuids);
     int countByProject(String projectName);
     int countExecutionReports(RdExecQuery execQuery);
-    int countExecutionReportsWithTransaction(RdExecQuery execQuery, boolean isJobs, String jobUuid);
     int countAndSaveByStatus();
-    List<RdExecReport> getExecutionReports(RdExecQuery execQuery, boolean isJobs, String jobUuid, List<String> executionUuids);
     void deleteByProject(String projectName);
     void deleteWithTransaction(String projectName);
     void deleteAllByExecutionUuid(String executionUuid);
+
+    /**
+     * Get execution reports with transaction and list of executions ids
+     * This method can be used when you already have the executions ids
+     * @param execQuery
+     * @param isJobs
+     * @param jobUuid
+     * @param executionUuids
+     * @return
+     */
+    List<RdExecReport> getExecutionReports(RdExecQuery execQuery, boolean isJobs, String jobUuid, List<Long> executionUuids);
+
+    /**
+     * Count execution reports with transaction and list of executions ids
+     * This method can be used when you already have the executionss ids
+     * @param query query
+     * @param isJobs is job
+     * @param jobUuid scheduled execution uuid
+     * @param execsId list of execution ids
+     * @return count
+     */
+    int countExecutionReportsWithTransaction(RdExecQuery query, boolean isJobs, String jobUuid, List<Long> execsId);
+
 }


### PR DESCRIPTION
This is an attempt to remove unnecessary methods and remove data-spi module from rundeckpro.

This pull request updates the data provider interfaces for executions and reports to support using execution IDs (as `Long`) instead of execution UUIDs (as `String`) for certain methods. This change makes the interfaces more flexible and better aligned with underlying database identifiers. The most important changes are grouped below:

### Execution Data Provider interface updates

* Added a new method `getExecutionIdsByJobUuid` to `ReferencedExecutionDataProvider` to retrieve execution IDs (`Long`) by job UUID, replacing the previous method that returned UUIDs as `String`.

### Execution Report Data Provider interface updates

* Added a new method `getExecutionReports` to `ExecReportDataProvider` that accepts a list of execution IDs (`Long`) instead of UUIDs (`String`).
* Added a new method `countExecutionReportsWithTransaction` to `ExecReportDataProvider` that accepts a list of execution IDs (`Long`).

These changes improve the ability to work directly with execution IDs and provide more flexible querying options.